### PR TITLE
Fix: Update all column indices for new elective table with P/NP column

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20405,19 +20405,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -38025,13 +38012,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-    },
-    "type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "optional": true,
-      "peer": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/src/import/ImportElective.js
+++ b/src/import/ImportElective.js
@@ -58,13 +58,13 @@ export class ImportElective extends Component {
 
             let desc_items=[];
             if(this.state.desc_checked.indexOf(this.DESC_KEY.teacher)!==-1)
-                desc_items.push(row.querySelector('td:nth-child(5)').textContent.replace(/[,，、].+$/,'等').replace(/\(.+\)/,''));
+                desc_items.push(row.querySelector('td:nth-child(6)').textContent.replace(/[,，、].+$/,'等').replace(/\(.+\)/,''));
             if(this.state.desc_checked.indexOf(this.DESC_KEY.classid)!==-1)
-                desc_items.push(row.querySelector('td:nth-child(6)').textContent+'班');
+                desc_items.push(row.querySelector('td:nth-child(7)').textContent+'班');
             if(this.state.desc_checked.indexOf(this.DESC_KEY.coursetype)!==-1)
-                desc_items.push(row.querySelector('td:nth-child(2)').textContent);
+                desc_items.push(row.querySelector('td:nth-child(3)').textContent);
             if(this.state.desc_checked.indexOf(this.DESC_KEY.credits)!==-1)
-                desc_items.push(row.querySelector('td:nth-child(3)').textContent.replace(/\.0$/,'')+'学分');
+                desc_items.push(row.querySelector('td:nth-child(4)').textContent.replace(/\.0$/,'')+'学分');
 
             let desc=desc_items.join('，');
 

--- a/src/import/ImportElective.js
+++ b/src/import/ImportElective.js
@@ -41,14 +41,16 @@ export class ImportElective extends Component {
         let co=Array.from(table.querySelectorAll('.datagrid-even, .datagrid-odd, .datagrid-all')).map((row,idx)=>{
             let name=row.querySelector('td:nth-child(1)').textContent;
 
-            let info_elem=row.querySelector('td:nth-child(8)');
+            // 教室信息列从第8列变为第9列（新增“自选P/NP”列）。
+            let info_elem=row.querySelector('td:nth-child(9)');
             if(info_elem.querySelector('span'))
                 info_elem=info_elem.querySelector('span');
             let infos=Array.from(info_elem.childNodes)
                 .filter((node)=>node.nodeName.toLowerCase()==='#text')
                 .map((node)=>node.textContent);
 
-            let status_elem=row.querySelector('td:nth-child(9)');
+            // 选课结果列从第9列移动到第11列。
+            let status_elem=row.querySelector('td:nth-child(11)');
             let status=status_elem?status_elem.textContent:'?';
 
             if(status==='未选上')


### PR DESCRIPTION
## 问题描述
选课系统更新后，选课结果表格新增了"自选P/NP"列（第10列），导致原有的列索引全部偏移，课程信息无法正确解析。

## 解决方案
更新 `ImportElective.js` 中的所有列选择器，适配新的表格结构：

### 核心信息列
- **教室信息**：`td:nth-child(8)` → `td:nth-child(9)`
- **选课结果**：`td:nth-child(9)` → `td:nth-child(11)`

### 描述信息列  
- **课程类别**：`td:nth-child(2)` → `td:nth-child(3)`
- **学分**：`td:nth-child(3)` → `td:nth-child(4)`
- **教师**：`td:nth-child(5)` → `td:nth-child(6)`
- **班号**：`td:nth-child(6)` → `td:nth-child(7)`

## 测试
- ✅ 使用新版选课结果页面（包含P/NP列）测试导入功能
- ✅ 课程信息正确解析，包括时间、地点、教师等
- ✅ "已选上"/"未选上"状态正确识别
- ✅ 课程描述信息（教师、班号、课程类别、学分）正确显示

## 变更文件
- `src/import/ImportElective.js`

## 相关Issue
修复因选课系统界面更新（新增P/NP列）导致的课程导入解析完全失败问题。