### PR TITLE
Fix column indices regression from #7

### DIFF
--- a/src/import/ImportElective.js
+++ b/src/import/ImportElective.js
@@ -37,11 +37,14 @@ export class ImportElective extends Component {
         if(!table)
             throw new Error('找不到选课结果列表，请确保选中了整个表格！');
 
+        let headers=Array.from(table.querySelectorAll('.datagrid-header th')).map((th)=>th.textContent.trim());
+        let statusCol=headers.indexOf('选课结果')+1;
+        if(statusCol===0) statusCol=10; // fallback
+
         let skip_co=[];
         let co=Array.from(table.querySelectorAll('.datagrid-even, .datagrid-odd, .datagrid-all')).map((row,idx)=>{
-            let name=row.querySelector('td:nth-child(1)').textContent;
+            let name=row.querySelector('td:nth-child(2)').textContent;
 
-            // 教室信息列从第8列变为第9列（新增“自选P/NP”列）。
             let info_elem=row.querySelector('td:nth-child(9)');
             if(info_elem.querySelector('span'))
                 info_elem=info_elem.querySelector('span');
@@ -49,8 +52,7 @@ export class ImportElective extends Component {
                 .filter((node)=>node.nodeName.toLowerCase()==='#text')
                 .map((node)=>node.textContent);
 
-            // 选课结果列从第9列移动到第11列。
-            let status_elem=row.querySelector('td:nth-child(11)');
+            let status_elem=row.querySelector('td:nth-child('+statusCol+')');
             let status=status_elem?status_elem.textContent:'?';
 
             if(status==='未选上')


### PR DESCRIPTION
## Summary
- Fix `name` reading 课程号 (col 1) instead of 课程名 (col 2) due to new table layout
- Dynamically detect 选课结果 column from header row to support both UG (13 cols, with 自选P/NP) and postgrad (12 cols, without P/NP)
- Remove outdated comments about P/NP column shift

## Context
The elective system now has 课程号 as the first column in both UG and postgrad tables. PR #7 adjusted some indices but left `name` pointing at col 1 and hardcoded `status` to col 11, which is only correct for UG.

## Test plan
- [x] Paste UG elective table (13 columns with 自选P/NP) → courses recognized correctly
- [x] Paste postgrad elective table (12 columns without P/NP) → courses recognized correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)